### PR TITLE
Fixed the rego parse error and hardcoded resource names in rego policy (ready to merge)

### DIFF
--- a/guardrails-validation/Dockerfile
+++ b/guardrails-validation/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:bullseye-slim
 
 WORKDIR /app
 
-ENV CONFTEST_VERSION=0.21.0
+ENV CONFTEST_VERSION=0.39.2
 COPY run.sh ./run.sh
 
 RUN apt update && apt install -y wget && wget https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz && \

--- a/guardrails-validation/install.sh
+++ b/guardrails-validation/install.sh
@@ -16,7 +16,7 @@
 
 #!/bin/bash
 
-export CONFTEST_VERSION=0.32.1
+export CONFTEST_VERSION=0.39.2
 
 wget https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz && \
 mkdir conftest && \


### PR DESCRIPTION
This PR should resolve the following issues:  #13

Changes:
- Refactroed the rego policy number 11
- Upgraded the conftest version to latest

Test Result:
- Verified that the rego parse error for the number 11 rego policy is gone from cloud build log.
- Verified that the number 11 rego policy validation passed from cloud build log.

Please see the test result evidence from the cloud build logs below.

```
starting build "1148baff-48fe-41af-a976-3bc5fcfe15f6"

FETCHSOURCE
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /workspace/.git/
From https://source.developers.google.com/p/lzpe-js08-guardrailsjs08/r/LzPeCLD-guardrails-policies-csr
 * branch            4aa15a70e4eab80f7adac9b8d7de2160a676309f -> FETCH_HEAD
HEAD is now at 4aa15a7 Patched at 2023-04-18.1804
BUILD
Starting Step #0
Step #0: Already have image (with digest): gcr.io/cloud-builders/gcloud
Step #0: Copying gs://lzpe565977066779assetsguardrailsjs08/organizations/565977066779.json...
Step #0: / [0 files][    0.0 B/  3.2 MiB]                                                
/ [1 files][  3.2 MiB/  3.2 MiB]                                                
Step #0: Operation completed over 1 objects/3.2 MiB.                                      
Finished Step #0
Starting Step #1
Step #1: Already have image (with digest): gcr.io/cloud-builders/docker
Finished Step #1
Starting Step #2
Step #2: Already have image (with digest): gcr.io/cloud-builders/docker
Step #2: Unable to find image 'northamerica-northeast1-docker.pkg.dev/lzpe-js08-guardrailsjs08/lzpecld-guardrails-af-registry-afr/lzpeccr-guardrails-policies-cntr:latest' locally
Step #2: latest: Pulling from lzpe-js08-guardrailsjs08/lzpecld-guardrails-af-registry-afr/lzpeccr-guardrails-policies-cntr
Step #2: 26c5c85e47da: Already exists
Step #2: f54c0c4d962e: Pulling fs layer
Step #2: a6e04e46b0b0: Pulling fs layer
Step #2: a0c34b0db63b: Pulling fs layer
Step #2: f54c0c4d962e: Verifying Checksum
Step #2: f54c0c4d962e: Download complete
Step #2: a6e04e46b0b0: Verifying Checksum
Step #2: a6e04e46b0b0: Download complete
Step #2: f54c0c4d962e: Pull complete
Step #2: a6e04e46b0b0: Pull complete
Step #2: a0c34b0db63b: Verifying Checksum
Step #2: a0c34b0db63b: Download complete
Step #2: a0c34b0db63b: Pull complete
Step #2: Digest: sha256:c786cddd81554911dcae89e445d6ecbf5a3ff1236f340ac6789315e6514eaf68
Step #2: Status: Downloaded newer image for northamerica-northeast1-docker.pkg.dev/lzpe-js08-guardrailsjs08/lzpecld-guardrails-af-registry-afr/lzpeccr-guardrails-policies-cntr:latest
Step #2: Checking ./assets/asset_inventory.json
Finished Step #2
Starting Step #3
Step #3: Already have image (with digest): gcr.io/cloud-builders/docker
Step #3: ./assets/asset_inventory.json
Step #3: +---------+------+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
Step #3: | RESULT  | FILE | NAMESPACE |                                                                                                        MESSAGE                                                                                                        |
Step #3: +---------+------+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
Step #3: | success | -    | main      | SUCCESS                                                                                                                                                                                                               |
Step #3: | success | -    | main      | SUCCESS                                                                                                                                                                                                               |
Step #3: | success | -    | main      | SUCCESS                                                                                                                                                                                                               |
Step #3: | failure | -    | main      | Guardrail # 5: Resource containerregistry.googleapis.com/Image                                                                                                                                                        |
Step #3: |         |      |           | ('//containerregistry.googleapis.com/us.gcr.io/gdse-ja-secguardrails/gcf/northamerica-northeast1/12517d9e-8c83-4602-b943-1fafb816343b/cache@sha256:ad9f0ccb7b82f76e4d4729595cc07dbcc35547c236a6a496746b2007293bfd95') |
Step #3: |         |      |           | is located in 'us' when it is required to be in '["northamerica-northeast1", "global"]'                                                                                                                               |
Step #3: | failure | -    | main      | Guardrail # 5: Resource containerregistry.googleapis.com/Image                                                                                                                                                        |
Step #3: |         |      |           | ('//containerregistry.googleapis.com/us.gcr.io/gdse-ja-secguardrails/gcf/northamerica-northeast1/12517d9e-8c83-4602-b943-1fafb816343b@sha256:85718805cf97613355494b8bd534418f0b94ace9b923e051dc7fbdd2866b8124')       |
Step #3: |         |      |           | is located in 'us' when it is required to be in '["northamerica-northeast1", "global"]'                                                                                                                               |
Step #3: | failure | -    | main      | Guardrail # 5: Resource containerregistry.googleapis.com/Image                                                                                                                                                        |
Step #3: |         |      |           | ('//containerregistry.googleapis.com/us.gcr.io/gdse-ja-secguardrails/gcf/northamerica-northeast1/12517d9e-8c83-4602-b943-1fafb816343b@sha256:a8689a312bf2db549ecc62c683bff3bf7b126317599ff9a8d733c72f9236f049')       |
Step #3: |         |      |           | is located in 'us' when it is required to be in '["northamerica-northeast1", "global"]'                                                                                                                               |
Step #3: | failure | -    | main      | Guardrail # 5: Resource containerregistry.googleapis.com/Image                                                                                                                                                        |
Step #3: |         |      |           | ('//containerregistry.googleapis.com/us.gcr.io/gdse-ja-secguardrails/gcf/northamerica-northeast1/e2d06603-d425-45f6-931d-65ad88761d22/cache@sha256:88b0e417217136757eea27578f1222cef40304cc551ba2abbfcfcb99c0ec362f') |
Step #3: |         |      |           | is located in 'us' when it is required to be in '["northamerica-northeast1", "global"]'                                                                                                                               |
Step #3: | failure | -    | main      | Guardrail # 5: Resource containerregistry.googleapis.com/Image                                                                                                                                                        |
Step #3: |         |      |           | ('//containerregistry.googleapis.com/us.gcr.io/gdse-ja-secguardrails/gcf/northamerica-northeast1/e2d06603-d425-45f6-931d-65ad88761d22@sha256:86daf3b023d0cb47b3d970cd09f415bd4d9bb69c2f70f224838772d4daaf1314')       |
Step #3: |         |      |           | is located in 'us' when it is required to be in '["northamerica-northeast1", "global"]'                                                                                                                               |
Step #3: +---------+------+-----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
Step #3: 
Finished Step #3
Starting Step #4
Step #4: Already have image (with digest): gcr.io/cloud-builders/docker
Finished Step #4
Starting Step #5
Step #5: Already have image (with digest): gcr.io/cloud-builders/gcloud
Step #5: Copying file:///assets/565977066779.json [Content-Type=application/json]...
Step #5: / [0 files][    0.0 B/  5.3 KiB]                                                
/ [1 files][  5.3 KiB/  5.3 KiB]                                                
Step #5: Operation completed over 1 objects/5.3 KiB.                                      
Finished Step #5
PUSH
DONE
```